### PR TITLE
Add shorter syntax option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,25 @@ $ npm install --save react-cool-inview
 
 > ⚠️ [Most modern browsers support Intersection Observer natively](https://caniuse.com/#feat=intersectionobserver). You can also [add polyfill](#intersection-observer-polyfill) for full browser support.
 
-### Basic Use Case
+### Basic usage
+
+Change the `HelloText` depending on whether it is in viewport or not:
+
+```jsx
+import { InView } from "react-cool-inview"
+
+const HelloText = ({ inView, observe }: any) => (
+  <div ref={observe}>{inView ? "Hello, I am 🤗" : "Bye, I am 😴"}</div>
+)
+
+const App = () => (
+  <InView>
+    <HelloText />
+  </InView>
+)
+```
+
+### Using as a React Hook
 
 To monitor an element enters or leaves the viewport by the `inView` state and useful sugar events.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,8 +27,7 @@ interface Event<T> {
   observe: Observe<T>;
   unobserve: () => void;
 }
-export interface 
-  <T> {
+export interface Options<T> {
   root?: HTMLElement | null;
   rootMargin?: string;
   threshold?: number | number[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import React, { useState, useRef, useEffect, useCallback } from "react";
 
 import useLatest from "./useLatest";
 
@@ -27,7 +27,8 @@ interface Event<T> {
   observe: Observe<T>;
   unobserve: () => void;
 }
-export interface Options<T> {
+export interface 
+  <T> {
   root?: HTMLElement | null;
   rootMargin?: string;
   threshold?: number | number[];
@@ -192,5 +193,15 @@ const useInView = <T extends HTMLElement | null>({
 
   return { ...state, observe, unobserve, updatePosition };
 };
+
+type InViewProps = {
+  children: React.ReactElement
+  options?: Options<any>
+}
+
+export const InView = ({ children, options }: InViewProps) => {
+  const { observe, ...rest } = useInView(options)
+  return React.cloneElement(children, { observe, ...rest })
+}
 
 export default useInView;


### PR DESCRIPTION
This makes the following usage possible:

```jsx
// This is an example of showing (animating) a React component when it appears in viewport:
import React from "react"
import { InView } from "react-cool-inview"

const FancyComponent = ({ inView, observe }: any) => (
  <div ref={observe} className={inView ? "opacity-1" : "opacity-0"}>
    {"Hello"}
  </div>
)

const App = () => (
  <InView unobserveOnEnter>
    <FancyComponent />
  </InView>
)
```

### Why?
It's much shorter than using hooks in this case which allows to style components faster. It's also more readable.

